### PR TITLE
docs: блок «Автор» с Telegram-каналом в README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -150,6 +150,10 @@ Patterns drawn from 15+ Russian-language sources (Habr, vc.ru, Gramota.ru, HSE s
 
 Changelog: [CHANGELOG.md](CHANGELOG.md). Metrics and eval harness: [`scripts/`](scripts/) and [`eval/`](eval/). Full Russian documentation: [README.md](README.md).
 
+## Author
+
+Ilya Utov. I write about AI and working with text on Telegram: [Under the Hood](https://t.me/gorilla_under_hood).
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ GPTZero, Originality.ai, ZeroGPT и другие популярные детек
 
 Changelog: [CHANGELOG.md](CHANGELOG.md). Метрики и eval-харнес: каталоги [`scripts/`](scripts/) и [`eval/`](eval/).
 
+## Автор
+
+Илья Утов. Пишу про AI и работу с текстом в Telegram: [Under the Hood](https://t.me/gorilla_under_hood).
+
 ## Лицензия
 
 MIT: используйте свободно, форкайте, дорабатывайте. Pull request с новыми паттернами приветствуются.


### PR DESCRIPTION
Добавлен раздел «## Автор» (RU) / «## Author» (EN) перед лицензией со ссылкой на Telegram-канал автора [Under the Hood](https://t.me/gorilla_under_hood). Без длинного тире. README остаётся самым трафиковым файлом проекта, профильный README репо дополняет это отдельно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)