### PR TITLE
маркетплейс: description на уровне маркетплейса

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "ilyautov-plugins",
+  "description": "Plugins by Ilya Utov: humanizer-ru kills AI smell in Russian text | Плагины Ильи Утова: humanizer-ru убирает следы нейросети из русского текста",
   "owner": {
     "name": "Ilya Utov",
     "email": "ilyautov@gmail.com"


### PR DESCRIPTION
Закрывает предупреждение `claude plugin validate`: у маркетплейса не было description. Версии и структура не меняются.

🤖 Generated with [Claude Code](https://claude.com/claude-code)