### PR TITLE
site: установка на первом экране и подсветка живого демо

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -16,6 +16,17 @@ Claude Code / Cowork plugin. Kills AI smell in Russian text. The English [humani
   </a>
 </p>
 
+🧪 **Live demo:** [humanizer-ru.aifrontier.tech](https://humanizer-ru.aifrontier.tech/#audit). Paste a Russian text, get a 0-100 cleanliness score and highlighted markers. Same scanner as in the skill, runs in the browser.
+
+**Quick start** in Claude Code, two commands:
+
+```
+/plugin marketplace add ilyautov/humanizer-ru
+/plugin install humanizer-ru@ilyautov-plugins
+```
+
+Cursor, Copilot, Cline and other agents: `npx skills add https://github.com/ilyautov/humanizer-ru/tree/main/skills/humanizer-ru`. Claude.ai, Codex, DeepSeek Harness and team rollout are covered in [Install](#install).
+
 📖 **Docs & write-ups (RU):** [humanizer-ru.aifrontier.tech](https://humanizer-ru.aifrontier.tech/): do AI detectors work on Russian, the 64 markers, plagiarism vs AI detection.
 
 ## What you get

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # humanizer-ru: очеловечить русский AI-текст для Claude Code, Cursor, Codex и других AI-агентов
 
-> Скилл для Claude. Убирает 64 признака нейросети в русском тексте: канцелярит, кальки, фингерпринты ChatGPT и Claude. Метит в то, что измеряют GPTZero, DivEye, RuBERT: поднимает perplexity и burstiness. 21 жёстких банов, quad-pass аудит, калибровка под голос автора, eval-харнес с метриками до/после.
+> Скилл для Claude. Убирает 64 признака нейросети в русском тексте: канцелярит, кальки, фингерпринты ChatGPT и Claude. Метит в то, что измеряют GPTZero, DivEye, RuBERT: поднимает perplexity и burstiness. 21 жёстких банов, quad-pass аудит, калибровка под голос автора, eval-харнес с метриками до/после. Живое демо сканера на сайте.
 
 > [English version](README.en.md)
 
@@ -20,6 +20,17 @@
 > **Стало (факты автора):** «Инструмент экономит команде сорок минут в день. Попробуйте теперь его у людей забрать».
 >
 > Три жёстких бана в одном предложении. [Полный разбор с режимом аудита ниже](#до-и-после).
+
+🧪 **Живое демо:** [humanizer-ru.aifrontier.tech](https://humanizer-ru.aifrontier.tech/#audit). Вставьте свой текст, получите оценку чистоты 0-100 и подсветку найденных оборотов. Тот же сканер, что в скилле, считается в браузере.
+
+**Быстрый старт** в Claude Code, две команды:
+
+```
+/plugin marketplace add ilyautov/humanizer-ru
+/plugin install humanizer-ru@ilyautov-plugins
+```
+
+Cursor, Copilot, Cline и другие агенты: `npx skills add https://github.com/ilyautov/humanizer-ru/tree/main/skills/humanizer-ru`. Claude.ai, Codex, DeepSeek Harness и раскатка на команду в [разделе «Установка»](#установка).
 
 📖 **Документация и разборы:** [humanizer-ru.aifrontier.tech](https://humanizer-ru.aifrontier.tech/): [работают ли AI-детекторы на русском](https://humanizer-ru.aifrontier.tech/ai-detektory-na-russkom.html), [64 признака AI-текста](https://humanizer-ru.aifrontier.tech/52-priznaka-ai-teksta.html), [антиплагиат и нейросеть](https://humanizer-ru.aifrontier.tech/antiplagiat-i-neyroset.html).
 

--- a/docs/audit.js
+++ b/docs/audit.js
@@ -5,7 +5,7 @@
   const $ = (id) => document.getElementById(id);
   const textEl = $("audit-text"), genreEl = $("audit-genre"), runBtn = $("audit-run");
   const countEl = $("audit-count"), resultEl = $("audit-result"), sourceEl = $("audit-source");
-  const markedWrap = $("audit-marked"), markedEl = $("audit-text-marked"), nextEl = $("audit-next");
+  const markedWrap = $("audit-marked"), markedEl = $("audit-text-marked"), nextEl = $("audit-next"), installEl = $("install");
   if (!textEl || typeof globalThis.humanizerScan !== "function") return;
 
   const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -46,7 +46,7 @@
 
   // --- Результат -------------------------------------------------------------
   function animateNumber(el, target) {
-    if (reduceMotion) { el.textContent = target; return; }
+    if (reduceMotion || document.hidden) { el.textContent = target; return; }
     const t0 = performance.now(), dur = 650;
     const step = (now) => {
       const k = Math.min(1, (now - t0) / dur);
@@ -99,14 +99,14 @@
   // --- Среды ------------------------------------------------------------------
   let envKey = ENVS[0].key;
   function renderEnvs() {
-    const tabs = nextEl.querySelector(".env-tabs");
+    const tabs = installEl.querySelector(".env-tabs");
     tabs.innerHTML = ENVS.map((e) =>
       `<button type="button" role="tab" data-env="${e.key}" aria-selected="${e.key === envKey}">${e.label}</button>`).join("");
     const env = ENVS.find((e) => e.key === envKey);
     $("env-cmd").textContent = env.cmd;
     $("env-note").textContent = env.note;
   }
-  nextEl.querySelector(".env-tabs").addEventListener("click", (ev) => {
+  installEl.querySelector(".env-tabs").addEventListener("click", (ev) => {
     const b = ev.target.closest("[data-env]");
     if (!b) return;
     envKey = b.dataset.env;
@@ -135,7 +135,6 @@
     renderResult(r);
     renderMarked(text, r);
     nextEl.hidden = false;
-    renderEnvs();
   }
 
   let timer = null;
@@ -154,4 +153,5 @@
   }));
 
   updateCount();
+  renderEnvs();
 })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -101,12 +101,30 @@
 <div class="wrap hero">
 
   <h1>Очеловечить русский AI-текст: убрать следы нейросети</h1>
-  <p class="lede">humanizer-ru это бесплатный open-source скилл для Claude, Cursor, Codex и других агентов. Берёт стерильный текст нейросети и возвращает в него живую русскую речь: с голосом, ритмом и характером. Не косметика по списку слов, а полноценный рерайт. Под капотом 64 признака AI-текста в 14 категориях и 21 жёстких запретов, сканер в комплекте.</p>
+  <p class="lede">Бесплатный open-source скилл для Claude, Cursor, Codex и других агентов: снимает с русского текста следы нейросети и возвращает голос автора. 64 признака, 21 жёстких запретов, сканер <a href="#audit">работает прямо на этой странице</a>.</p>
+
+  <section class="install" id="install" aria-labelledby="install-title">
+    <div class="install-head">
+      <h2 id="install-title" class="plain">Поставить за минуту</h2>
+      <p>Выберите среду и скопируйте команду. Проверить текст можно и без установки, в демо ниже.</p>
+    </div>
+    <div class="env-tabs" role="tablist" aria-label="Среда установки"></div>
+    <div class="env-panel" role="tabpanel">
+      <div class="env-cmd-wrap">
+        <pre class="env-cmd"><code id="env-cmd"></code></pre>
+        <button type="button" class="env-copy" id="env-copy" aria-label="Скопировать команду">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+          <span>Скопировать</span>
+        </button>
+      </div>
+      <p class="env-note" id="env-note"></p>
+    </div>
+  </section>
 
   <section class="audit" id="audit" aria-labelledby="audit-title">
     <div class="audit-head">
-      <h2 id="audit-title" class="plain">Проверьте текст прямо здесь</h2>
-      <p>Тот же сканер, что едет со скиллом, только на JavaScript. Считается в браузере, текст никуда не отправляется.</p>
+      <h2 id="audit-title" class="plain">Живое демо: проверьте свой текст</h2>
+      <p>Тот же сканер, что едет со скиллом, только на JavaScript. Считается в браузере, текст никуда не отправляется. Вставьте абзац или возьмите готовый пример.</p>
     </div>
 
     <div class="audit-grid">
@@ -152,17 +170,7 @@
     </div>
 
     <div class="audit-next" id="audit-next" hidden>
-      <h3 class="plain">Исправить в вашей среде</h3>
-      <p>Сканер только показывает, что выдаёт текст. Переписывает скилл, установленный в агент. Выберите свой:</p>
-      <div class="env-tabs" role="tablist" aria-label="Среда установки"></div>
-      <div class="env-panel" role="tabpanel">
-        <pre class="env-cmd"><code id="env-cmd"></code></pre>
-        <button type="button" class="env-copy" id="env-copy" aria-label="Скопировать команду">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-          <span>Скопировать</span>
-        </button>
-        <p class="env-note" id="env-note"></p>
-      </div>
+      <p>Сканер только показывает, что выдаёт текст. Переписывает скилл, установленный в агент: <a href="#install">команды установки выше</a>.</p>
       <p class="audit-note">В браузере считаются запреты, маркеры, ритм и структура. Номинальность (сущ./глаг.) добавляет только scan.py в комплекте скилла, поэтому его оценка бывает ниже на несколько баллов. Числа сканера это основания для правки, а не вердикт об авторстве.</p>
     </div>
   </section>

--- a/docs/style.css
+++ b/docs/style.css
@@ -165,8 +165,8 @@ pre code { background: none; border: none; padding: 0; }
 /* Онлайн-аудит на первом экране */
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 .audit {
-  margin: 1.6em 0 2.4em;
-  border: 1px solid var(--border);
+  margin: 1.2em 0 2.4em;
+  border: 1px solid #7aa7ff66;
   border-radius: var(--radius);
   background: var(--bg-soft);
   box-shadow: 0 18px 48px -28px rgba(0, 0, 0, 0.9);
@@ -285,11 +285,21 @@ mark.ban, mark.mk { color: inherit; border-radius: 3px; padding: 0 2px; text-dec
 mark.ban { background: #f8717126; text-decoration-color: var(--bad); }
 mark.mk { background: #fbbf2422; text-decoration-color: var(--warn); }
 
-.audit-next { padding: 0 22px 20px; border-top: 1px solid var(--border); }
-.audit-next h3 { margin: 18px 0 4px; }
-.audit-next > p { margin: 0 0 10px; color: var(--text-dim); font-size: 0.92em; }
+.audit-next { padding: 14px 22px 20px; border-top: 1px solid var(--border); }
+.audit-next > p { margin: 0; color: var(--text-dim); font-size: 0.92em; }
+
+/* Установка на первом экране */
+.install {
+  margin: 1.4em 0 0;
+  padding: 16px 22px 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-soft);
+}
+.install-head h2 { margin: 0 0 4px; font-size: 1.15em; }
+.install-head p { margin: 0 0 12px; color: var(--text-dim); font-size: 0.92em; }
 .env-tabs { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
-.env-panel { position: relative; }
+.env-cmd-wrap { position: relative; }
 .env-cmd { margin: 0; padding-right: 150px; min-height: 52px; }
 .env-copy {
   position: absolute; top: 10px; right: 10px;
@@ -534,7 +544,7 @@ tr:last-child td { border-bottom: none; }
   body { font-size: 16px; }
   .cards, .ba { grid-template-columns: 1fr; }
   .audit-grid { grid-template-columns: 1fr; padding: 14px 16px 16px; }
-  .audit-head, .audit-marked, .audit-next { padding-left: 16px; padding-right: 16px; }
+  .audit-head, .audit-marked, .audit-next, .install { padding-left: 16px; padding-right: 16px; }
   .audit-result { min-height: 0; }
   .audit-run { margin-left: 0; width: 100%; text-align: center; }
   .env-cmd { padding-right: 16px; padding-bottom: 48px; }


### PR DESCRIPTION
Блок установки (вкладки сред + команда) поднят под заголовок, лид сокращён. Демо получило заголовок «Живое демо» и акцентную рамку. README RU/EN: живое демо и быстрый старт над разделом «Зачем». Кнопка копирования на мобильном больше не перекрывает подпись.