### PR TITLE
Ссылка на витрину со всех страниц сайта

### DIFF
--- a/docs/52-priznaka-ai-teksta.html
+++ b/docs/52-priznaka-ai-teksta.html
@@ -283,6 +283,7 @@
           <li><a href="https://github.com/ilyautov/humanizer-ru">GitHub: репозиторий и установка</a></li>
           <li><a href="https://t.me/gorilla_under_hood">Telegram: Under the Hood</a></li>
           <li><a href="https://aifrontier.tech/sistemy/humanizer-ru/">AI Frontier: лаборатория, которая это делает</a></li>
+          <li><a href="https://ilyautov.github.io/">Все проекты: 21 открытый инструмент</a></li>
         </ul>
       </div>
     </div>

--- a/docs/ai-detektory-na-russkom.html
+++ b/docs/ai-detektory-na-russkom.html
@@ -247,6 +247,7 @@
           <li><a href="https://github.com/ilyautov/humanizer-ru">GitHub: репозиторий и установка</a></li>
           <li><a href="https://t.me/gorilla_under_hood">Telegram: Under the Hood</a></li>
           <li><a href="https://aifrontier.tech/sistemy/humanizer-ru/">AI Frontier: лаборатория, которая это делает</a></li>
+          <li><a href="https://ilyautov.github.io/">Все проекты: 21 открытый инструмент</a></li>
         </ul>
       </div>
     </div>

--- a/docs/antiplagiat-i-neyroset.html
+++ b/docs/antiplagiat-i-neyroset.html
@@ -255,6 +255,7 @@
           <li><a href="https://github.com/ilyautov/humanizer-ru">GitHub: репозиторий и установка</a></li>
           <li><a href="https://t.me/gorilla_under_hood">Telegram: Under the Hood</a></li>
           <li><a href="https://aifrontier.tech/sistemy/humanizer-ru/">AI Frontier: лаборатория, которая это делает</a></li>
+          <li><a href="https://ilyautov.github.io/">Все проекты: 21 открытый инструмент</a></li>
         </ul>
       </div>
     </div>

--- a/docs/gumanizator-teksta.html
+++ b/docs/gumanizator-teksta.html
@@ -157,6 +157,7 @@
           <li><a href="privacy.html">Приватность расширения</a></li>
           <li><a href="https://t.me/gorilla_under_hood">Telegram: Under the Hood</a></li>
           <li><a href="https://aifrontier.tech/sistemy/humanizer-ru/">AI Frontier: лаборатория, которая это делает</a></li>
+          <li><a href="https://ilyautov.github.io/">Все проекты: 21 открытый инструмент</a></li>
         </ul>
       </div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -321,6 +321,7 @@
           <li><a href="privacy.html">Приватность расширения</a></li>
           <li><a href="https://t.me/gorilla_under_hood">Telegram: Under the Hood</a></li>
           <li><a href="https://aifrontier.tech/sistemy/humanizer-ru/">AI Frontier: лаборатория, которая это делает</a></li>
+          <li><a href="https://ilyautov.github.io/">Все проекты: 21 открытый инструмент</a></li>
         </ul>
       </div>
     </div>

--- a/docs/kak-ubrat-sledy-neyroseti.html
+++ b/docs/kak-ubrat-sledy-neyroseti.html
@@ -188,6 +188,7 @@
           <li><a href="https://github.com/ilyautov/humanizer-ru">GitHub: репозиторий и установка</a></li>
           <li><a href="https://t.me/gorilla_under_hood">Telegram: Under the Hood</a></li>
           <li><a href="https://aifrontier.tech/sistemy/humanizer-ru/">AI Frontier: лаборатория, которая это делает</a></li>
+          <li><a href="https://ilyautov.github.io/">Все проекты: 21 открытый инструмент</a></li>
         </ul>
       </div>
     </div>

--- a/docs/kancelyarit.html
+++ b/docs/kancelyarit.html
@@ -184,6 +184,7 @@
           <li><a href="privacy.html">Приватность расширения</a></li>
           <li><a href="https://t.me/gorilla_under_hood">Telegram: Under the Hood</a></li>
           <li><a href="https://aifrontier.tech/sistemy/humanizer-ru/">AI Frontier: лаборатория, которая это делает</a></li>
+          <li><a href="https://ilyautov.github.io/">Все проекты: 21 открытый инструмент</a></li>
         </ul>
       </div>
     </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -100,6 +100,7 @@
           <li><a href="https://github.com/ilyautov/humanizer-ru">GitHub: репозиторий и установка</a></li>
           <li><a href="https://t.me/gorilla_under_hood">Telegram: Under the Hood</a></li>
           <li><a href="https://aifrontier.tech/sistemy/humanizer-ru/">AI Frontier: лаборатория, которая это делает</a></li>
+          <li><a href="https://ilyautov.github.io/">Все проекты: 21 открытый инструмент</a></li>
         </ul>
       </div>
     </div>

--- a/docs/proverit-tekst-na-neyroset.html
+++ b/docs/proverit-tekst-na-neyroset.html
@@ -226,6 +226,7 @@
           <li><a href="privacy.html">Приватность расширения</a></li>
           <li><a href="https://t.me/gorilla_under_hood">Telegram: Under the Hood</a></li>
           <li><a href="https://aifrontier.tech/sistemy/humanizer-ru/">AI Frontier: лаборатория, которая это делает</a></li>
+          <li><a href="https://ilyautov.github.io/">Все проекты: 21 открытый инструмент</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Зачем

Вечерний замер источников трафика: humanizer-ru даёт 79,5% всех просмотров профиля (4 178 из 5 254 за 14 дней), а витрина `ilyautov.github.io` получила один визит за две недели. Витрина при этом единственная страница профиля, с которой ссылки передают вес: из README ссылки помечены nofollow.

Проверил ссылочный граф по всем семи живым сайтам. На витрину ссылаются шесть из семи: aifrontier.tech, small-business-ru, business-mcp-ru, marketplaces-mcp-ru, moysklad-mcp-ru. Не ссылается ровно один сайт, самый сильный, и это humanizer-ru: ноль упоминаний витрины на всех девяти страницах.

## Что сделано

По одной строке в подвал каждой из девяти страниц, в колонку «Проект», рядом с GitHub и Telegram. Формулировка и место те же, что у соседних сайтов («Все проекты»). Новых блоков, баннеров и сквозных перелинковок нет.

## Проверка

`grep -c ilyautov.github.io docs/*.html` = 1 на каждой из девяти страниц, было 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)